### PR TITLE
add people space docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 mod_authnz_persona is a module for Apache 2.0 or later that allows you to
 quickly add Persona authentication to a site hosted with Apache.
 
+# Use on people.mozilla.org
+
+If you would like to enable LDAP authentication on your Mozilla people space,
+add a file named *.htaccess* in the folder you would like to secure. It should
+have the following contents:
+
+    SSLRequireSSL On
+    AuthType Persona
+    require valid-user
+
+For example, if you would like to require LDAP authentication for https://people.mozilla.org/~username/secure you would put *.htaccess* in *~/public_html/secure/*
+
+Remember to browse the website via HTTPS as it won't work otherwise.
+
 # Installation
 
 First, install the dependencies:


### PR DESCRIPTION
I learned about this module from the following MOTD:

> Persona authentication is now available via your .htaccess files. See
> https://github.com/gozer-mozilla/mod_authn_persona for more details.

I tried following the instructions in the README, however I could not get LDAP authentication working. After searching on bugzilla, I found [this comment](https://bugzilla.mozilla.org/show_bug.cgi?id=994114#c10) which helped to resolve my issues.

In order to prevent someone else spending their time trying to figure it out, I've documented what needs to be done in order to get this module working on people space.
