### PR TITLE
Removing confusing reference to "LDAP"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ have the following contents:
     AuthType Persona
     require valid-user
 
-For example, if you would like to require LDAP authentication for https://people.mozilla.org/~username/secure you would put *.htaccess* in *~/public_html/secure/*
+For example, if you would like to require Persona authentication for https://people.mozilla.org/~username/secure you would put *.htaccess* in *~/public_html/secure/*
 
 Remember to browse the website via HTTPS as it won't work otherwise.
 


### PR DESCRIPTION
As far as I can tell the example .htaccess requires a valid Persona account, but has nothing to do with LDAP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gozer/mod_authn_persona/2)
<!-- Reviewable:end -->
